### PR TITLE
do not set/reset Better Pawn Control policy if none is configured

### DIFF
--- a/Source/GearUpAndGizGo.cs
+++ b/Source/GearUpAndGizGo.cs
@@ -31,7 +31,7 @@ namespace GearUpAndGo
 			Log.Message($"GearUpAndGo to {target}, setting {policy}");
 
 			if (!Event.current.alt)
-				GearUpPolicyComp.comp.Set(policy);
+				GearUpPolicyComp.comp.Set(policy ?? Mod.settings.betterPawnControlBattlePolicy);
 
 			foreach (Pawn p in Find.Selector.SelectedObjects
 				.Where(o => o is Pawn p && p.IsColonistPlayerControlled).Cast<Pawn>())
@@ -90,11 +90,12 @@ namespace GearUpAndGo
 		}
 		public void Set(string policy)
 		{
+			if (policy == "") return;
 			if (lastPolicy == "")
 			{
 				lastPolicy = SetBetterPawnControl.CurrentPolicy();
 			}
-			SetBetterPawnControl.SetPawnControlPolicy(policy ?? Mod.settings.betterPawnControlBattlePolicy);
+			SetBetterPawnControl.SetPawnControlPolicy(policy);
 		}
 		public void Revert()
 		{


### PR DESCRIPTION
There are other ways to set BPC policies, such as BPC's own alert state. With that this mod's handling becomes superfluous and in fact an additional chore, as it is necessary to explicitly unset this mod's policy state, and it must be done before reverting BPC's, otherwise this mod would set the battle policy again.